### PR TITLE
Fixed the session chooser to start selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -56,8 +56,24 @@ function show_error(text) {
 
 // called when the greeter is finished the authentication request
 function authentication_complete() {
+  var container = document.querySelector("#session_container");
+  var children = container.querySelectorAll("input");
+  var i = 0;
+  var key = "";
+  for (i = 0; i < children.length; i++) {
+    var child = children[i];
+    if (child.checked) {
+      key = child.value;
+      break;
+    }
+  }
+
   if (lightdm.is_authenticated) {
-    lightdm.login(lightdm.authentication_user, lightdm.default_session);
+    if (key === "") {
+      lightdm.login(lightdm.authentication_user, lightdm.default_session);
+    } else {
+      lightdm.login(lightdm.authentication_user, key);
+    }
   } else {
     show_error("Authentication Failed");
     start_authentication(selected_user);
@@ -103,11 +119,11 @@ function initialize_sessions() {
     label.innerHTML = session.name;
     radio.value = session.key;
 
-    if (session.key === lightdm.default_session.key) {
+    if (session.key === lightdm.default_session) {
       radio.checked = true;
     }
 
-    session_container.appendChild(s);
+    container.appendChild(s);
   }
 }
 


### PR DESCRIPTION
The session choosing options will now highlight the default session
as defined in lightdm.conf (lightdm.default_session is the key, it
cannot be accessed with lightdm.default_session.key).

Additionally, the selected option will now be considered when
calling lightdm.login instead of passing the default session; if
any of the radio buttons is selected, the corresponding key will be
used, otherwise, lightdm.default_session is passed as before.
