### PR TITLE
When default session is 'default' select first one.

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -9,7 +9,7 @@ if (typeof lightdm == 'undefined') {
 	lightdm.layout= lightdm.layouts[0];
 	lightdm.sessions=[{key: "key1", name: "session 1", comment: "no comment"}, {key: "key2", name: "session 2", comment: "no comment"}];
 
-	lightdm.default_session=lightdm.sessions[0];
+	lightdm.default_session=lightdm.sessions[0].key;
 	lightdm.authentication_user= null;
 	lightdm.is_authenticated= false;
 	lightdm.can_suspend= true;

--- a/script.js
+++ b/script.js
@@ -119,7 +119,8 @@ function initialize_sessions() {
     label.innerHTML = session.name;
     radio.value = session.key;
 
-    if (session.key === lightdm.default_session) {
+    var default_session = 'default' == lightdm.default_session && 0 == i;
+    if (session.key === lightdm.default_session || default_session) {
       radio.checked = true;
     }
 


### PR DESCRIPTION
LightDM sets the default session key to 'default', use the first one then.
In the mockup script set the default session to the key value, not the entire session object.
Fix for issue #6 